### PR TITLE
Adding support for changing/overriding table name for list (knex adapter).

### DIFF
--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -266,7 +266,7 @@ class KnexListAdapter extends BaseListAdapter {
     super(...arguments);
     this.getListAdapterByKey = parentAdapter.getListAdapterByKey.bind(parentAdapter);
     this.realKeys = [];
-    this.tableName = this.key;
+    this.tableName = this.config.tableName || this.key;
     this.rels = undefined;
   }
 


### PR DESCRIPTION
Adding support for changing/overriding table name for list (knex adapter).

```javascript
keystone.createList('User', {
    adapterName: 'cms',
    adapterConfig: {
      tableName: 'customers'
    },
    fields: {
      name: { type: Text },
      email: {
        type: Text,
        isUnique: true,
      },
      isAdmin: {
        type: Checkbox,
        // Field-level access controls
        // Here, we set more restrictive field access so a non-admin cannot make themselves admin.
        access: {
          update: access.userIsAdmin,
        },
      },
      password: {
        type: Password,
      },
    },
    // List-level access controls
    access: {
      read: access.userIsAdminOrOwner,
      update: access.userIsAdminOrOwner,
      create: access.userIsAdmin,
      delete: access.userIsAdmin,
      auth: true,
    },
  });
```